### PR TITLE
feat(approval-queue): inline agent controls, status header, and nav updates

### DIFF
--- a/src/constants/dashboard.ts
+++ b/src/constants/dashboard.ts
@@ -67,18 +67,6 @@ const AI_AGENTS = [
     href: "/wismo-agent",
   },
   {
-    id: "subscription",
-    name: "Subscription Agent",
-    icon: Bot,
-    href: "/subscription-agent",
-  },
-  {
-    id: "returns",
-    name: "Returns Agent",
-    icon: Package,
-    href: "/returns-agent",
-  },
-  {
     id: "promo_code",
     name: "Promo Code Agent",
     icon: Tag,
@@ -102,6 +90,18 @@ const AI_AGENTS = [
     icon: Package,
     href: "/order-cancellations",
   },
+  {
+    id: "subscription",
+    name: "Subscription Agent",
+    icon: Bot,
+    href: "/subscription-agent",
+  },
+  // {
+  //   id: "returns",
+  //   name: "Returns Agent",
+  //   icon: Package,
+  //   href: "/returns-agent",
+  // },
 ];
 
 const DASHBOARD = {

--- a/src/constants/sidebar.ts
+++ b/src/constants/sidebar.ts
@@ -19,6 +19,7 @@ import type { LucideIcon } from "lucide-react";
 // Primary navigation - frequently used features
 const PRIMARY_NAVIGATION = [
   { name: "Dashboard", href: "/dashboard", icon: Satellite },
+  { name: "Approval Queue", href: "/approval-queue", icon: CheckCircle },
   { name: "AI Assistant", href: "/ai-assistant", icon: Bot },
   {
     name: "Quick Actions",
@@ -28,7 +29,6 @@ const PRIMARY_NAVIGATION = [
   },
   { name: "AI Agents", href: "#", icon: Users }, // Dropdown menu, no direct route
   { name: "AI Team Center", href: "/ai-training", icon: Brain },
-  { name: "Approval Queue", href: "/approval-queue", icon: CheckCircle },
 ];
 
 export type AiAgentNavItem = {
@@ -41,25 +41,25 @@ export type AiAgentNavItem = {
 // AI Agents submenu navigation
 const AI_AGENTS_NAVIGATION: AiAgentNavItem[] = [
   { name: "WISMO Agent", href: "/wismo-agent", icon: Truck },
-  {
-    name: "Subscription Agent",
-    href: "/subscription-agent",
-    icon: Bot,
-    comingSoon: true,
-  },
-  { name: "Product Agent", href: "/product-agent", icon: Brain },
-  {
-    name: "Returns Agent",
-    href: "/returns-agent",
-    icon: Package,
-    comingSoon: true,
-  },
+  // {
+  //   name: "Returns Agent",
+  //   href: "/returns-agent",
+  //   icon: Package,
+  //   comingSoon: true,
+  // },
   { name: "Promo Code Agent", href: "/promo-code-agent", icon: Tag },
+  { name: "Product Agent", href: "/product-agent", icon: Brain },
   { name: "Address Change Agent", href: "/address-change-agent", icon: MapPin },
   {
     name: "Cancellation Agent",
     href: "/order-cancellation-agent",
     icon: Package,
+  },
+  {
+    name: "Subscription Agent",
+    href: "/subscription-agent",
+    icon: Bot,
+    comingSoon: true,
   },
 ];
 

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/agent-controls.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/agent-controls.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import { FC } from "react";
+import { Power, ShieldCheck } from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useAiAgents } from "@/providers/ai-agents";
+import { useUpdateSpecificAIAgentSettings } from "@/hooks/services/ai-agents/use-update-specific-ai-agent-settings";
+import { ApprovalQueueAgentCategory } from "@/modules/protected-routes/approval-queue/utils/constants";
+import { AiAgentsEnum } from "@/types/ai-agents";
+import { cn } from "@/lib/utils";
+
+type AgentControlsProps = {
+  category: Exclude<ApprovalQueueAgentCategory, ApprovalQueueAgentCategory.ALL>;
+  agentName: string;
+};
+
+// The two enums share the same string values
+// (e.g. "wismo", "promo_code"), so the approval-queue category can be used
+// directly as a key into the AI Agents settings DTO map.
+const toAgentEnum = (
+  category: AgentControlsProps["category"],
+): AiAgentsEnum => category as unknown as AiAgentsEnum;
+
+export const AgentControls: FC<AgentControlsProps> = ({
+  category,
+  agentName,
+}) => {
+  const { aiAgentsSettings, isFetchingAgentsSettings } = useAiAgents();
+  const { updateAIAgentSettings, isUpdating } =
+    useUpdateSpecificAIAgentSettings();
+
+  const agent = aiAgentsSettings[toAgentEnum(category)];
+  const agentApiId = agent?.id;
+  const isEnabled = agent?.isEnabled ?? false;
+  const requiresModeration = agent?.requiresModeration ?? false;
+
+  const hasAgent = Boolean(agentApiId);
+  const controlsBusy = isUpdating || isFetchingAgentsSettings;
+  const disableEnableSwitch = controlsBusy || !hasAgent;
+  const disableModerationSwitch = disableEnableSwitch || !isEnabled;
+
+  const handleToggleEnabled = (checked: boolean) => {
+    if (!agentApiId) return;
+    if (checked) {
+      updateAIAgentSettings({
+        params: { agentId: agentApiId, isEnabled: true },
+      });
+    } else {
+      // Disabling the agent also clears the moderation flag, mirroring
+      // the behaviour of the dedicated agent settings pages.
+      updateAIAgentSettings({
+        params: {
+          agentId: agentApiId,
+          isEnabled: false,
+          requiresModeration: false,
+        },
+      });
+    }
+  };
+
+  const handleToggleModeration = (checked: boolean) => {
+    if (!agentApiId) return;
+    updateAIAgentSettings({
+      params: { agentId: agentApiId, requiresModeration: checked },
+    });
+  };
+
+  // While the initial agent settings request is in-flight we render a
+  // placeholder so the card layout doesn't jump once data lands.
+  if (isFetchingAgentsSettings && !hasAgent) {
+    return (
+      <div className="flex items-center gap-2 rounded-full border border-border/60 bg-muted/40 px-3 py-1.5">
+        <Skeleton className="h-4 w-12" />
+        <Skeleton className="h-4 w-8" />
+        <div className="h-4 w-px bg-border/70" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-4 w-8" />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 sm:gap-3 rounded-full border border-border/70 bg-muted/40 px-3 py-1.5",
+        "transition-colors",
+      )}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label
+            htmlFor={`agent-enable-${agentApiId}`}
+            className={cn(
+              "flex items-center gap-1.5",
+              disableEnableSwitch
+                ? "cursor-not-allowed opacity-70"
+                : "cursor-pointer",
+            )}
+          >
+            <Power
+              className={cn(
+                "size-3.5 transition-colors",
+                isEnabled ? "text-primary" : "text-muted-foreground",
+              )}
+            />
+            <span className="hidden text-xs font-medium text-foreground sm:inline">
+              Agent
+            </span>
+            <Switch
+              id={`agent-enable-${agentApiId}`}
+              checked={isEnabled}
+              onCheckedChange={handleToggleEnabled}
+              disabled={disableEnableSwitch}
+              aria-label={`Toggle ${agentName}`}
+            />
+          </label>
+        </TooltipTrigger>
+        <TooltipContent>
+          {hasAgent
+            ? isEnabled
+              ? `Disable ${agentName}`
+              : `Enable ${agentName}`
+            : "Agent settings unavailable"}
+        </TooltipContent>
+      </Tooltip>
+
+      <div className="h-4 w-px bg-border/70" />
+
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <label
+            htmlFor={`agent-moderation-${agentApiId}`}
+            className={cn(
+              "flex items-center gap-1.5",
+              disableModerationSwitch
+                ? "cursor-not-allowed opacity-70"
+                : "cursor-pointer",
+            )}
+          >
+            <ShieldCheck
+              className={cn(
+                "size-3.5 transition-colors",
+                requiresModeration ? "text-primary" : "text-muted-foreground",
+              )}
+            />
+            <span className="hidden text-xs font-medium text-foreground sm:inline">
+              Moderation
+            </span>
+            <Switch
+              id={`agent-moderation-${agentApiId}`}
+              checked={requiresModeration}
+              onCheckedChange={handleToggleModeration}
+              disabled={disableModerationSwitch}
+              aria-label={`Toggle moderation for ${agentName}`}
+            />
+          </label>
+        </TooltipTrigger>
+        <TooltipContent>
+          {!hasAgent
+            ? "Agent settings unavailable"
+            : !isEnabled
+              ? "Enable the agent to control moderation"
+              : requiresModeration
+                ? "Auto-send responses without review"
+                : "Require human review before sending"}
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+};

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { Calendar, Mail, Pencil, User } from "lucide-react";
+import { Calendar, ChevronDown, Mail, Pencil, User } from "lucide-react";
 import { Stepper } from "@mantine/core";
 import { FC, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -22,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { useGetApprovalQueueItem } from "./use-approval-queue-item";
 import { htmlToPlainText } from "@/modules/protected-routes/approval-queue/utils/html-to-plain-text";
+import { AgentControls } from "./agent-controls";
 
 const PROPOSED_EMAIL_HTML_RE = /<[a-z][^>]*>/i;
 
@@ -108,59 +108,103 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
     textColor,
   } = AGENT_METADATA_MAP[category];
 
+  const statusStyles = APPROVAL_QUEUE_STATUS_STYLES[status];
+  const StatusIcon = statusStyles?.icon;
+
   return (
-    <Card className="gap-2 border-l-8 border-l-orange-500">
+    <Card
+      className={cn(
+        "gap-2 border-l-8",
+        statusStyles?.leftBorder ?? "border-l-orange-500",
+      )}
+    >
       <CardHeader>
-        <div
-          className={cn(
-            "p-2 rounded-full flex items-center gap-2 w-fit",
-            bgColor,
-            textColor,
-          )}
-        >
-          <AgentIcon className="h-6 w-6" />
-          <span className="text-sm font-medium">{agentName}</span>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex w-fit items-center overflow-hidden rounded-full border border-border/40 shadow-sm">
+            <div
+              className={cn(
+                "flex items-center gap-2 px-3 py-2",
+                bgColor,
+                textColor,
+              )}
+            >
+              <AgentIcon className="h-5 w-5" />
+              <span className="text-sm font-medium">{agentName}</span>
+            </div>
+            <div
+              className={cn(
+                "flex items-center gap-2 px-3 py-2",
+                statusStyles?.pill,
+              )}
+            >
+              {StatusIcon && <StatusIcon className="h-5 w-5" />}
+              <span className="text-sm font-medium">
+                {ApprovalQueueItemsFilterLabelMap[status]}
+              </span>
+            </div>
+          </div>
+          <AgentControls category={category} agentName={agentName} />
         </div>
       </CardHeader>
       <CardContent>
         <Collapsible>
           <CollapsibleTrigger asChild>
-            <div className="flex flex-col gap-2 w-full rounded-lg p-2 hover:cursor-pointer hover:bg-secondary">
-              <div className="flex items-center gap-8 justify-between w-full">
-                <div className="flex items-center gap-2">
-                  <Mail />
-                  <p className="text-xl font-semibold line-clamp-1">
-                    {emailSubject}
-                  </p>
-                </div>
-                <Badge
-                  variant="outline"
+            <div className="group flex w-full flex-col gap-2 rounded-lg p-2 hover:cursor-pointer hover:bg-secondary">
+              <div className="flex items-start gap-2 w-full min-w-0">
+                <Mail className="size-5 sm:size-6 mt-0.5 shrink-0" />
+                <p
                   className={cn(
-                    "border font-medium",
-                    APPROVAL_QUEUE_STATUS_STYLES[status]?.badge,
+                    "min-w-0 flex-1 font-semibold break-words",
+                    "text-base sm:text-lg lg:text-xl",
+                    "line-clamp-2 lg:line-clamp-1",
+                    "group-data-[state=open]:line-clamp-none",
                   )}
+                  title={emailSubject}
                 >
-                  <span
-                    className={cn(
-                      "mr-1.5 h-1.5 w-1.5 rounded-full",
-                      APPROVAL_QUEUE_STATUS_STYLES[status]?.dot,
-                    )}
-                  />
-                  {ApprovalQueueItemsFilterLabelMap[status]}
-                </Badge>
+                  {emailSubject}
+                </p>
               </div>
-              <div className="flex items-center gap-3 w-full">
-                <div className="flex items-center gap-2">
-                  <User className="size-4" />
-                  <p className="text-md text-secondary-foreground line-clamp-1">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 w-full">
+                <div className="flex items-center gap-2 min-w-0 max-w-full">
+                  <User className="size-4 shrink-0" />
+                  <p
+                    className="text-sm sm:text-md text-secondary-foreground line-clamp-1 break-all"
+                    title={customerEmail}
+                  >
                     {customerEmail}
                   </p>
                 </div>
-                <div className="flex items-center gap-2">
-                  <Calendar className="size-4" />
-                  <p className="text-md text-secondary-foreground line-clamp-1">
+                <div className="flex items-center gap-2 shrink-0">
+                  <Calendar className="size-4 shrink-0" />
+                  <p className="text-sm sm:text-md text-secondary-foreground line-clamp-1">
                     {format(new Date(createdAt), "MMM dd, yyyy")}
                   </p>
+                </div>
+              </div>
+              <div className="flex w-full items-center justify-end pt-1">
+                <div
+                  className={cn(
+                    "flex items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5",
+                    "text-xs font-semibold",
+                    "border border-primary/30 bg-primary/10 text-primary",
+                    "shadow-sm transition-all duration-200",
+                    "group-hover:bg-primary group-hover:text-primary-foreground group-hover:border-primary group-hover:shadow-md",
+                    "group-data-[state=open]:bg-primary group-data-[state=open]:text-primary-foreground group-data-[state=open]:border-primary",
+                  )}
+                  aria-hidden
+                >
+                  <span className="group-data-[state=open]:hidden">
+                    View actions
+                  </span>
+                  <span className="hidden group-data-[state=open]:inline">
+                    Hide actions
+                  </span>
+                  <ChevronDown
+                    className={cn(
+                      "size-4 transition-transform duration-200",
+                      "group-data-[state=open]:rotate-180",
+                    )}
+                  />
                 </div>
               </div>
             </div>

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/utils/index.ts
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/utils/index.ts
@@ -4,7 +4,19 @@ import {
 } from "../../../utils/constants";
 import { AgentMetadata } from "../../../utils/types";
 import { APPROVAL_QUEUE_ITEMS_FILTER_OPTIONS } from "./constants";
-import { Brain, CreditCard, MapPin, Package, Tag, Truck } from "lucide-react";
+import {
+  AlertTriangle,
+  Brain,
+  CheckCircle2,
+  Clock,
+  CreditCard,
+  LucideIcon,
+  MapPin,
+  Package,
+  Tag,
+  Truck,
+  XCircle,
+} from "lucide-react";
 
 export const ApprovalQueueItemsFilterLabelMap = Object.fromEntries(
   APPROVAL_QUEUE_ITEMS_FILTER_OPTIONS.map((option) => [
@@ -21,23 +33,46 @@ export const ApprovalQueueItemsFilterLabelMap = Object.fromEntries(
  */
 export const APPROVAL_QUEUE_STATUS_STYLES: Record<
   ApprovalQueueItemStatus,
-  { dot: string; badge: string }
+  {
+    /** Dot used by the status filter dropdown */
+    dot: string;
+    /** Outline badge variant (kept for any compact usage) */
+    badge: string;
+    /** Left border color for the queue card */
+    leftBorder: string;
+    /** Filled pill background + text color matching the agent badge */
+    pill: string;
+    /** Status icon rendered inside the pill */
+    icon: LucideIcon;
+  }
 > = {
   [ApprovalQueueItemStatus.IN_PROGRESS]: {
     dot: "bg-sky-500",
     badge: "border-sky-200 bg-sky-50 text-sky-700",
+    leftBorder: "border-l-sky-500",
+    pill: "bg-sky-100 text-sky-700",
+    icon: Clock,
   },
   [ApprovalQueueItemStatus.CANCELLED]: {
     dot: "bg-rose-500",
     badge: "border-rose-200 bg-rose-50 text-rose-700",
+    leftBorder: "border-l-rose-500",
+    pill: "bg-rose-100 text-rose-700",
+    icon: XCircle,
   },
   [ApprovalQueueItemStatus.COMPLETED]: {
     dot: "bg-emerald-500",
     badge: "border-emerald-200 bg-emerald-50 text-emerald-700",
+    leftBorder: "border-l-emerald-500",
+    pill: "bg-emerald-100 text-emerald-700",
+    icon: CheckCircle2,
   },
   [ApprovalQueueItemStatus.ESCALATED]: {
     dot: "bg-amber-500",
     badge: "border-amber-200 bg-amber-50 text-amber-800",
+    leftBorder: "border-l-amber-500",
+    pill: "bg-amber-100 text-amber-700",
+    icon: AlertTriangle,
   },
 };
 


### PR DESCRIPTION
## Summary

This PR adds inline **agent enable / moderation** controls on approval queue cards, refines **status presentation** (header pill, left border, icons), and updates **primary and AI agent navigation** (Approval Queue placement, agent ordering, Returns agent commented out in dashboard and sidebar).

## Changes

- **Approval queue item** (`approval-queue-item/index.tsx`): Combined agent + status pill in the header; status-driven left border; integrated `AgentControls`; collapsible trigger shows subject/customer/date with improved wrapping and a clear “View actions / Hide actions” affordance.
- **Agent controls** (`agent-controls.tsx`, new): Power and moderation switches wired to existing AI agent settings hooks, with tooltips, loading skeleton, and click isolation from the collapsible row.
- **Status styling** (`approval-queue-items-list/utils/index.ts`): Extended `APPROVAL_QUEUE_STATUS_STYLES` with `leftBorder`, `pill`, and `icon` for cards while keeping dot/badge for filter UI.
- **Navigation** (`sidebar.ts`): Approval Queue moved earlier in primary nav; AI Agents submenu reordered; Returns Agent entry commented.
- **Dashboard** (`dashboard.ts`): AI Agents list reordered to match; Returns Agent entry commented.

## Testing checklist

- [ ] Open **Approval Queue** and confirm cards show agent name, status pill, and correct left border per status.
- [ ] Expand/collapse a row: subject clamps/unwraps as expected; “View actions / Hide actions” and chevron state match open/closed.
- [ ] Toggle **Agent** and **Moderation** on a card; verify API updates and disabled states when agent is off or settings missing.
- [ ] Sidebar: **Approval Queue** appears in the expected position; AI Agents submenu order matches product intent; no broken links for visible agents.
- [ ] Dashboard AI Agents section: order and visibility match sidebar (Returns not shown).

## Notes / Rollback

- Returns Agent is only commented in constants; restore the blocks to re-enable.
- Revert commit `cc50225` to roll back this PR’s functional changes.

### Commits

```
cc50225 feat(approval-queue): inline agent controls, status header, and nav updates
```
