### PR TITLE
feat(approval-queue): action status stepper visuals and cancel workflow API

### DIFF
--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/action-pill-styles.ts
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/action-pill-styles.ts
@@ -1,0 +1,8 @@
+export const approvalQueueActionPillBaseClass =
+  "flex h-8 w-full items-center justify-start rounded-full px-3 shadow-sm transition-all duration-200";
+
+export const approvalQueueActionPillIconClass =
+  "mr-1.5 flex w-4 shrink-0 items-center justify-center";
+
+export const approvalQueueActionPillTextClass =
+  "text-xs font-semibold leading-none";

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/agent-controls.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/agent-controls.tsx
@@ -88,7 +88,8 @@ export const AgentControls: FC<AgentControlsProps> = ({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 sm:gap-3 rounded-full border border-border/70 bg-muted/40 px-3 py-1.5",
+        "flex max-w-full shrink-0 flex-wrap items-center gap-x-2 gap-y-1.5 sm:gap-x-3",
+        "rounded-full border border-border/70 bg-muted/40 px-3 py-1.5",
         "transition-colors",
       )}
       onClick={(e) => e.stopPropagation()}
@@ -98,7 +99,7 @@ export const AgentControls: FC<AgentControlsProps> = ({
           <label
             htmlFor={`agent-enable-${agentApiId}`}
             className={cn(
-              "flex items-center gap-1.5",
+              "flex shrink-0 items-center gap-1.5",
               disableEnableSwitch
                 ? "cursor-not-allowed opacity-70"
                 : "cursor-pointer",
@@ -106,11 +107,11 @@ export const AgentControls: FC<AgentControlsProps> = ({
           >
             <Power
               className={cn(
-                "size-3.5 transition-colors",
+                "size-3.5 shrink-0 transition-colors",
                 isEnabled ? "text-primary" : "text-muted-foreground",
               )}
             />
-            <span className="hidden text-xs font-medium text-foreground sm:inline">
+            <span className="whitespace-nowrap text-xs font-medium text-foreground">
               Agent
             </span>
             <Switch
@@ -131,14 +132,12 @@ export const AgentControls: FC<AgentControlsProps> = ({
         </TooltipContent>
       </Tooltip>
 
-      <div className="h-4 w-px bg-border/70" />
-
       <Tooltip>
         <TooltipTrigger asChild>
           <label
             htmlFor={`agent-moderation-${agentApiId}`}
             className={cn(
-              "flex items-center gap-1.5",
+              "flex shrink-0 items-center gap-1.5 border-l border-border/70 pl-2 sm:pl-3",
               disableModerationSwitch
                 ? "cursor-not-allowed opacity-70"
                 : "cursor-pointer",
@@ -146,11 +145,11 @@ export const AgentControls: FC<AgentControlsProps> = ({
           >
             <ShieldCheck
               className={cn(
-                "size-3.5 transition-colors",
+                "size-3.5 shrink-0 transition-colors",
                 requiresModeration ? "text-primary" : "text-muted-foreground",
               )}
             />
-            <span className="hidden text-xs font-medium text-foreground sm:inline">
+            <span className="whitespace-nowrap text-xs font-medium text-foreground">
               Moderation
             </span>
             <Switch

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/cancel-workflow-button.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/cancel-workflow-button.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { FC, SyntheticEvent } from "react";
+import { CircleStop } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  approvalQueueActionPillBaseClass,
+  approvalQueueActionPillIconClass,
+  approvalQueueActionPillTextClass,
+} from "./action-pill-styles";
+
+type CancelWorkflowButtonProps = {
+  disabled?: boolean;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCancel: () => void;
+  className?: string;
+};
+
+const stopTriggerPropagation = (event: SyntheticEvent) => {
+  event.stopPropagation();
+};
+
+export const CancelWorkflowButton: FC<CancelWorkflowButtonProps> = ({
+  disabled = false,
+  open,
+  onOpenChange,
+  onCancel,
+  className,
+}) => {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            approvalQueueActionPillBaseClass,
+            approvalQueueActionPillTextClass,
+            "appearance-none border-0 bg-destructive text-white hover:bg-destructive/90",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive/30 focus-visible:ring-offset-2",
+            "disabled:pointer-events-none disabled:opacity-50",
+            className,
+          )}
+          onPointerDown={stopTriggerPropagation}
+          onClick={stopTriggerPropagation}
+        >
+          <span className={approvalQueueActionPillIconClass}>
+            <CircleStop className="size-4 shrink-0" />
+          </span>
+          <span className={approvalQueueActionPillTextClass}>Cancel workflow</span>
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent onPointerDown={stopTriggerPropagation}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Stop this workflow?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The workflow will be cancelled and will no longer continue processing
+            this item.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Go back</AlertDialogCancel>
+          <AlertDialogAction
+            className={buttonVariants({ variant: "destructive" })}
+            onClick={onCancel}
+          >
+            Yes, cancel workflow
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
@@ -8,10 +8,13 @@ import {
 } from "@/components/ui/collapsible";
 import { Calendar, ChevronDown, Mail, Pencil, User } from "lucide-react";
 import { Stepper } from "@mantine/core";
-import { FC, useEffect, useState } from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ApprovalQueueItemData } from "@/modules/protected-routes/approval-queue/utils/types";
+import {
+  ApprovalQueueItemStatus,
+} from "@/modules/protected-routes/approval-queue/utils/constants";
 import {
   AGENT_METADATA_MAP,
   APPROVAL_QUEUE_STATUS_STYLES,
@@ -22,6 +25,14 @@ import { format } from "date-fns";
 import { useGetApprovalQueueItem } from "./use-approval-queue-item";
 import { htmlToPlainText } from "@/modules/protected-routes/approval-queue/utils/html-to-plain-text";
 import { AgentControls } from "./agent-controls";
+import { CancelWorkflowButton } from "./cancel-workflow-button";
+import { approvalQueueActionPillBaseClass, approvalQueueActionPillIconClass, approvalQueueActionPillTextClass } from "./action-pill-styles";
+import {
+  getWorkflowActionStepDescription,
+  getWorkflowActionStepLabel,
+  getWorkflowActionStepVisuals,
+  getWorkflowStepperActiveIndex,
+} from "./workflow-action-step";
 
 const PROPOSED_EMAIL_HTML_RE = /<[a-z][^>]*>/i;
 
@@ -65,6 +76,7 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
     isApprovingAction,
     isEditApprovingAction,
     isRejectingAction,
+    cancelWorkflow,
   } = useGetApprovalQueueItem({
     approvalQueueId: id,
     workflowActions,
@@ -72,6 +84,24 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
 
   const [isEditingProposedEmail, setIsEditingProposedEmail] = useState(false);
   const [editedEmailBody, setEditedEmailBody] = useState("");
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const suppressActionsToggleRef = useRef(false);
+
+  const handleCancelDialogOpenChange = (open: boolean) => {
+    if (!open) {
+      suppressActionsToggleRef.current = true;
+      requestAnimationFrame(() => {
+        suppressActionsToggleRef.current = false;
+      });
+    }
+    setIsCancelDialogOpen(open);
+  };
+
+  const handleActionsOpenChange = (open: boolean) => {
+    if (isCancelDialogOpen || suppressActionsToggleRef.current) return;
+    setIsActionsOpen(open);
+  };
 
   useEffect(() => {
     setIsEditingProposedEmail(false);
@@ -83,10 +113,10 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
     }
   }, [pendingWorkflowAction]);
 
-  const stepperActive =
-    pendingWorkflowActionIndex >= 0
-      ? pendingWorkflowActionIndex
-      : workflowActions.length;
+  const stepperActive = getWorkflowStepperActiveIndex(
+    workflowActions,
+    pendingWorkflowActionIndex,
+  );
 
   const isActionButtonBusy =
     isApprovingAction || isEditApprovingAction || isRejectingAction;
@@ -110,6 +140,7 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
 
   const statusStyles = APPROVAL_QUEUE_STATUS_STYLES[status];
   const StatusIcon = statusStyles?.icon;
+  const isInProgress = status === ApprovalQueueItemStatus.IN_PROGRESS;
 
   return (
     <Card
@@ -119,7 +150,7 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
       )}
     >
       <CardHeader>
-        <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-col items-start gap-3 min-[650px]:flex-row min-[650px]:items-center min-[650px]:justify-between">
           <div className="flex w-fit items-center overflow-hidden rounded-full border border-border/40 shadow-sm">
             <div
               className={cn(
@@ -147,68 +178,97 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
         </div>
       </CardHeader>
       <CardContent>
-        <Collapsible>
-          <CollapsibleTrigger asChild>
-            <div className="group flex w-full flex-col gap-2 rounded-lg p-2 hover:cursor-pointer hover:bg-secondary">
-              <div className="flex items-start gap-2 w-full min-w-0">
-                <Mail className="size-5 sm:size-6 mt-0.5 shrink-0" />
-                <p
-                  className={cn(
-                    "min-w-0 flex-1 font-semibold break-words",
-                    "text-base sm:text-lg lg:text-xl",
-                    "line-clamp-2 lg:line-clamp-1",
-                    "group-data-[state=open]:line-clamp-none",
-                  )}
-                  title={emailSubject}
-                >
-                  {emailSubject}
-                </p>
-              </div>
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-1 w-full">
-                <div className="flex items-center gap-2 min-w-0 max-w-full">
-                  <User className="size-4 shrink-0" />
+        <Collapsible
+          open={isActionsOpen}
+          onOpenChange={handleActionsOpenChange}
+          className="group"
+        >
+          <div className="flex w-full flex-col gap-2 rounded-lg p-2">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="flex w-full flex-col gap-2 rounded-lg text-left hover:cursor-pointer hover:bg-secondary"
+              >
+                <div className="flex items-start gap-2 w-full min-w-0">
+                  <Mail className="size-5 sm:size-6 mt-0.5 shrink-0" />
                   <p
-                    className="text-sm sm:text-md text-secondary-foreground line-clamp-1 break-all"
-                    title={customerEmail}
+                    className={cn(
+                      "min-w-0 flex-1 font-semibold break-words",
+                      "text-base sm:text-lg lg:text-xl",
+                    )}
+                    title={emailSubject}
                   >
-                    {customerEmail}
+                    {emailSubject}
                   </p>
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  <Calendar className="size-4 shrink-0" />
-                  <p className="text-sm sm:text-md text-secondary-foreground line-clamp-1">
-                    {format(new Date(createdAt), "MMM dd, yyyy")}
-                  </p>
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 w-full">
+                  <div className="flex items-center gap-2 min-w-0 max-w-full">
+                    <User className="size-4 shrink-0" />
+                    <p
+                      className="text-sm sm:text-md text-secondary-foreground line-clamp-1 break-all"
+                      title={customerEmail}
+                    >
+                      {customerEmail}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <Calendar className="size-4 shrink-0" />
+                    <p className="text-sm sm:text-md text-secondary-foreground line-clamp-1">
+                      {format(new Date(createdAt), "MMM dd, yyyy")}
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <div className="flex w-full items-center justify-end pt-1">
+              </button>
+            </CollapsibleTrigger>
+            <div className="ml-auto inline-flex w-max flex-col items-stretch gap-2 pt-1">
+              {isInProgress && (
+                <CancelWorkflowButton
+                  disabled={disableActionButtons}
+                  open={isCancelDialogOpen}
+                  onOpenChange={handleCancelDialogOpenChange}
+                  onCancel={() => {
+                    cancelWorkflow(undefined, {
+                      onSuccess: () => setIsCancelDialogOpen(false),
+                    });
+                  }}
+                />
+              )}
+              <CollapsibleTrigger asChild>
                 <div
                   className={cn(
-                    "flex items-center gap-1.5 whitespace-nowrap rounded-full px-3 py-1.5",
-                    "text-xs font-semibold",
-                    "border border-primary/30 bg-primary/10 text-primary",
-                    "shadow-sm transition-all duration-200",
-                    "group-hover:bg-primary group-hover:text-primary-foreground group-hover:border-primary group-hover:shadow-md",
-                    "group-data-[state=open]:bg-primary group-data-[state=open]:text-primary-foreground group-data-[state=open]:border-primary",
+                    approvalQueueActionPillBaseClass,
+                    "cursor-pointer border border-primary bg-primary text-primary-foreground shadow-md",
+                    "hover:bg-primary/90 hover:border-primary",
                   )}
-                  aria-hidden
                 >
-                  <span className="group-data-[state=open]:hidden">
+                  <span className={approvalQueueActionPillIconClass}>
+                    <ChevronDown
+                      className={cn(
+                        "size-4 shrink-0 transition-transform duration-200",
+                        "group-data-[state=open]:rotate-180",
+                      )}
+                    />
+                  </span>
+                  <span
+                    className={cn(
+                      approvalQueueActionPillTextClass,
+                      "group-data-[state=open]:hidden",
+                    )}
+                  >
                     View actions
                   </span>
-                  <span className="hidden group-data-[state=open]:inline">
+                  <span
+                    className={cn(
+                      approvalQueueActionPillTextClass,
+                      "hidden group-data-[state=open]:inline",
+                    )}
+                  >
                     Hide actions
                   </span>
-                  <ChevronDown
-                    className={cn(
-                      "size-4 transition-transform duration-200",
-                      "group-data-[state=open]:rotate-180",
-                    )}
-                  />
                 </div>
-              </div>
+              </CollapsibleTrigger>
             </div>
-          </CollapsibleTrigger>
+          </div>
           <CollapsibleContent className="flex flex-col items-start gap-4 p-2.5 text-sm">
             <div className="flex flex-col gap-2 w-full">
               <p className="font-semibold">Original Email Content</p>
@@ -224,17 +284,24 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
               orientation="vertical"
               iconSize={37}
             >
-              {workflowActions.map((action, index) => (
-                <Stepper.Step
-                  key={action.id}
-                  label={action.name || `Workflow Action ${index + 1}`}
-                  description={action.description}
-                  loading={
-                    isActionButtonBusy &&
-                    pendingWorkflowAction?.id === action.id
-                  }
-                />
-              ))}
+              {workflowActions.map((action, index) => {
+                const stepVisuals = getWorkflowActionStepVisuals(action.status);
+
+                return (
+                  <Stepper.Step
+                    key={action.id}
+                    label={getWorkflowActionStepLabel(action, index)}
+                    description={getWorkflowActionStepDescription(action)}
+                    color={stepVisuals.color}
+                    completedIcon={stepVisuals.completedIcon}
+                    progressIcon={stepVisuals.progressIcon}
+                    loading={
+                      isActionButtonBusy &&
+                      pendingWorkflowAction?.id === action.id
+                    }
+                  />
+                );
+              })}
             </Stepper>
             <div className="ps-[49px] flex flex-col gap-3 items-start w-full">
               {pendingWorkflowAction?.actionDetails && (

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/use-approval-queue-item.ts
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/use-approval-queue-item.ts
@@ -70,6 +70,25 @@ export const useGetApprovalQueueItem = ({
     },
   });
 
+  const { mutate: cancelWorkflow, isPending: isCancellingWorkflow } =
+    useMutation({
+      mutationFn: () =>
+        api.approval_queue_service.cancelApprovalQueueWorkflow({
+          id: approvalQueueId,
+        }),
+      onSuccess: (response) => {
+        invalidateApprovalQueries(queryClient, approvalQueueId);
+        toast.success(
+          response.message || "Workflow cancelled successfully",
+        );
+      },
+      onError: (error) => {
+        toast.error("Failed to cancel workflow", {
+          description: error instanceof Error ? error.message : undefined,
+        });
+      },
+    });
+
   const pendingWorkflowAction = workflowActions.find(
     (action) =>
       action.status === ApprovalQueueWorkflowActionStatus.PENDING_APPROVAL,
@@ -92,7 +111,12 @@ export const useGetApprovalQueueItem = ({
     isEditApprovingAction,
     rejectAction,
     isRejectingAction,
+    cancelWorkflow,
+    isCancellingWorkflow,
     disableActionButtons:
-      isApprovingAction || isEditApprovingAction || isRejectingAction,
+      isApprovingAction ||
+      isEditApprovingAction ||
+      isRejectingAction ||
+      isCancellingWorkflow,
   };
 };

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/workflow-action-step.ts
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/workflow-action-step.ts
@@ -1,0 +1,181 @@
+import { ApprovalQueueWorkflowActionStatus } from "@/modules/protected-routes/approval-queue/utils/constants";
+import { ApprovalQueueWorkflowAction } from "@/modules/protected-routes/approval-queue/utils/types";
+import {
+  AlertTriangle,
+  Check,
+  CircleStop,
+  Clock,
+  Loader2,
+  LucideIcon,
+  XCircle,
+} from "lucide-react";
+import { createElement, ReactNode } from "react";
+
+const TERMINAL_ACTION_STATUSES: ApprovalQueueWorkflowActionStatus[] = [
+  ApprovalQueueWorkflowActionStatus.ESCALATED,
+  ApprovalQueueWorkflowActionStatus.REJECTED,
+  ApprovalQueueWorkflowActionStatus.FAILED,
+  ApprovalQueueWorkflowActionStatus.CANCELLED,
+];
+
+const IN_PROGRESS_ACTION_STATUSES: ApprovalQueueWorkflowActionStatus[] = [
+  ApprovalQueueWorkflowActionStatus.PENDING_APPROVAL,
+  ApprovalQueueWorkflowActionStatus.EXECUTING,
+  ApprovalQueueWorkflowActionStatus.AWAITING_CUSTOMER_REPLY,
+];
+
+const ACTION_STATUS_LABELS: Partial<
+  Record<ApprovalQueueWorkflowActionStatus, { text: string; className: string }>
+> = {
+  [ApprovalQueueWorkflowActionStatus.ESCALATED]: {
+    text: "Escalated",
+    className: "text-amber-700",
+  },
+  [ApprovalQueueWorkflowActionStatus.REJECTED]: {
+    text: "Rejected",
+    className: "text-rose-700",
+  },
+  [ApprovalQueueWorkflowActionStatus.FAILED]: {
+    text: "Failed",
+    className: "text-rose-700",
+  },
+  [ApprovalQueueWorkflowActionStatus.CANCELLED]: {
+    text: "Cancelled",
+    className: "text-slate-600",
+  },
+};
+
+type WorkflowActionStepVisuals = {
+  color: string;
+  completedIcon: ReactNode;
+  progressIcon: ReactNode;
+};
+
+const renderStepIcon = (Icon: LucideIcon) =>
+  createElement(Icon, {
+    className: "size-[60%]",
+    strokeWidth: 2.5,
+  });
+
+const WORKFLOW_ACTION_STEP_VISUALS: Record<
+  ApprovalQueueWorkflowActionStatus,
+  WorkflowActionStepVisuals
+> = {
+  [ApprovalQueueWorkflowActionStatus.EXECUTED]: {
+    color: "teal",
+    completedIcon: renderStepIcon(Check),
+    progressIcon: renderStepIcon(Check),
+  },
+  [ApprovalQueueWorkflowActionStatus.ESCALATED]: {
+    color: "yellow",
+    completedIcon: renderStepIcon(AlertTriangle),
+    progressIcon: renderStepIcon(AlertTriangle),
+  },
+  [ApprovalQueueWorkflowActionStatus.REJECTED]: {
+    color: "red",
+    completedIcon: renderStepIcon(XCircle),
+    progressIcon: renderStepIcon(XCircle),
+  },
+  [ApprovalQueueWorkflowActionStatus.FAILED]: {
+    color: "red",
+    completedIcon: renderStepIcon(XCircle),
+    progressIcon: renderStepIcon(XCircle),
+  },
+  [ApprovalQueueWorkflowActionStatus.PENDING_APPROVAL]: {
+    color: "blue",
+    completedIcon: renderStepIcon(Clock),
+    progressIcon: renderStepIcon(Clock),
+  },
+  [ApprovalQueueWorkflowActionStatus.APPROVED]: {
+    color: "blue",
+    completedIcon: renderStepIcon(Check),
+    progressIcon: renderStepIcon(Loader2),
+  },
+  [ApprovalQueueWorkflowActionStatus.EXECUTING]: {
+    color: "blue",
+    completedIcon: renderStepIcon(Loader2),
+    progressIcon: renderStepIcon(Loader2),
+  },
+  [ApprovalQueueWorkflowActionStatus.AWAITING_CUSTOMER_REPLY]: {
+    color: "blue",
+    completedIcon: renderStepIcon(Clock),
+    progressIcon: renderStepIcon(Clock),
+  },
+  [ApprovalQueueWorkflowActionStatus.CANCELLED]: {
+    color: "gray",
+    completedIcon: renderStepIcon(CircleStop),
+    progressIcon: renderStepIcon(CircleStop),
+  },
+};
+
+const findLastActionIndexByStatus = (
+  workflowActions: ApprovalQueueWorkflowAction[],
+  statuses: ApprovalQueueWorkflowActionStatus[],
+): number =>
+  workflowActions.reduce(
+    (lastIndex, action, index) =>
+      statuses.includes(action.status) ? index : lastIndex,
+    -1,
+  );
+
+export const getWorkflowStepperActiveIndex = (
+  workflowActions: ApprovalQueueWorkflowAction[],
+  pendingWorkflowActionIndex: number,
+): number => {
+  if (pendingWorkflowActionIndex >= 0) {
+    return pendingWorkflowActionIndex;
+  }
+
+  const inProgressActionIndex = findLastActionIndexByStatus(
+    workflowActions,
+    IN_PROGRESS_ACTION_STATUSES,
+  );
+
+  if (inProgressActionIndex >= 0) {
+    return inProgressActionIndex;
+  }
+
+  const terminalActionIndex = findLastActionIndexByStatus(
+    workflowActions,
+    TERMINAL_ACTION_STATUSES,
+  );
+
+  if (terminalActionIndex >= 0) {
+    return workflowActions.length;
+  }
+
+  return workflowActions.length;
+};
+
+export const getWorkflowActionStepVisuals = (
+  status: ApprovalQueueWorkflowActionStatus,
+): WorkflowActionStepVisuals =>
+  WORKFLOW_ACTION_STEP_VISUALS[status] ??
+  WORKFLOW_ACTION_STEP_VISUALS[ApprovalQueueWorkflowActionStatus.EXECUTED];
+
+export const getWorkflowActionStepLabel = (
+  action: ApprovalQueueWorkflowAction,
+  index: number,
+): ReactNode => {
+  const actionName = action.name || `Workflow Action ${index + 1}`;
+  const statusLabel = ACTION_STATUS_LABELS[action.status];
+
+  if (!statusLabel) {
+    return actionName;
+  }
+
+  return createElement(
+    "span",
+    { className: "flex flex-col gap-0.5" },
+    createElement("span", null, actionName),
+    createElement(
+      "span",
+      { className: `text-xs font-semibold ${statusLabel.className}` },
+      statusLabel.text,
+    ),
+  );
+};
+
+export const getWorkflowActionStepDescription = (
+  action: ApprovalQueueWorkflowAction,
+): ReactNode => action.description;

--- a/src/modules/protected-routes/approval-queue/utils/constants/index.ts
+++ b/src/modules/protected-routes/approval-queue/utils/constants/index.ts
@@ -36,4 +36,6 @@ export enum ApprovalQueueWorkflowActionStatus {
   FAILED = "failed",
   ESCALATED = "escalated",
   REJECTED = "rejected",
+  AWAITING_CUSTOMER_REPLY = "awaiting_customer_reply",
+  CANCELLED = "cancelled",
 }

--- a/src/modules/protected-routes/approval-queue/utils/types/index.ts
+++ b/src/modules/protected-routes/approval-queue/utils/types/index.ts
@@ -33,6 +33,8 @@ export interface ApprovalQueueWorkflowAction {
   step: string;
   createdAt: string;
   proposedEmailBody: string | null;
+  escalationId: string | null;
+  escalationReason: string | null;
 }
 
 export interface ApprovalQueueItemData {

--- a/src/providers/approval-queue/index.tsx
+++ b/src/providers/approval-queue/index.tsx
@@ -49,9 +49,8 @@ export const useApprovalQueueContext = (): ApprovalQueueContextType => {
 export const ApprovalQueueProvider: FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [selectedItemStatus, setSelectedItemStatus] = useState<
-    ApprovalQueueItemStatus | null
-  >(null);
+  const [selectedItemStatus, setSelectedItemStatus] =
+    useState<ApprovalQueueItemStatus | null>(null);
   const [activeAgentCategory, setActiveAgentCategory] =
     useState<ApprovalQueueAgentCategory>(ApprovalQueueAgentCategory.ALL);
   const [currentPage, setCurrentPage] = useState<number>(1);

--- a/src/services/approval-queue/constants/index.ts
+++ b/src/services/approval-queue/constants/index.ts
@@ -4,7 +4,7 @@ const GET_APPROVAL_QUEUE_ITEMS = "/approval-queue";
 const GET_APPROVAL_QUEUE_WORKFLOWS = "/approval-queue/workflows";
 const GET_APPROVAL_QUEUE_ITEM_BY_ID = ({ itemId }: { itemId: string }) =>
   `/approval-queue/${encodeURIComponent(itemId)}`;
-const CANCEL_APPROVAL_QUEUE_ITEM_WORKFLOW = "approval-queue/cancel";
+const CANCEL_APPROVAL_QUEUE_ITEM_WORKFLOW = "/approval-queue/cancel";
 const APPROVE_APPROVAL_QUEUE_ACTION = ({ actionId }: { actionId: string }) =>
   `/approval-queue/actions/${encodeURIComponent(actionId)}/approve`;
 const REJECT_APPROVAL_QUEUE_ACTION = ({ actionId }: { actionId: string }) =>

--- a/src/services/approval-queue/index.ts
+++ b/src/services/approval-queue/index.ts
@@ -5,6 +5,8 @@ import {
 } from "@/modules/protected-routes/approval-queue/utils/types";
 import { APPROVAL_QUEUE_ENDPOINTS } from "./constants";
 import {
+  CANCEL_APPROVAL_QUEUE_WORKFLOW_PARAMS,
+  CANCEL_APPROVAL_QUEUE_WORKFLOW_RESPONSE,
   EDIT_AND_APPROVE_WORKFLOW_ACTION_PARAMS,
   GET_APPROVAL_QUEUE_ITEM_BY_ID_PARAMS,
   GET_APPROVAL_QUEUE_ITEMS_PARAMS,
@@ -56,13 +58,13 @@ export class ApprovalQueueService {
 
     return response;
   };
-  // Cancel Approval Queue Workflow by Id
-  cancelApprovalQueueWorkflowById = async (id: string) => {
-    const response = await apiService.post(
+  // Cancel an in-progress approval queue workflow
+  cancelApprovalQueueWorkflow = async (
+    params: CANCEL_APPROVAL_QUEUE_WORKFLOW_PARAMS,
+  ) => {
+    const response = await apiService.post<CANCEL_APPROVAL_QUEUE_WORKFLOW_RESPONSE>(
       APPROVAL_QUEUE_ENDPOINTS.CANCEL_APPROVAL_QUEUE_ITEM_WORKFLOW,
-      {
-        workflowId: id,
-      },
+      params,
     );
 
     return response;

--- a/src/services/approval-queue/types/index.ts
+++ b/src/services/approval-queue/types/index.ts
@@ -33,3 +33,12 @@ export type EDIT_AND_APPROVE_WORKFLOW_ACTION_PARAMS = {
   id: string;
   editedResponse: string;
 };
+
+export type CANCEL_APPROVAL_QUEUE_WORKFLOW_PARAMS = {
+  id?: string;
+  workflowId?: string;
+};
+
+export type CANCEL_APPROVAL_QUEUE_WORKFLOW_RESPONSE = {
+  message: string;
+};


### PR DESCRIPTION
## Summary

Improves approval queue workflow action visibility and adds real cancel-workflow integration. Escalated, rejected, and cancelled steps now use distinct stepper icons and labels instead of misleading blue checkmarks, and in-progress items can be cancelled via `POST /approval-queue/cancel`.

## Changes

- **Workflow stepper** — Per-action status visuals (executed, escalated, rejected, failed, cancelled, in-progress) with correct active-step logic
- **Cancel workflow** — New cancel button with confirmation dialog for `in_progress` items; calls backend with approval queue `id`
- **Types & API** — Added `escalationId`, `escalationReason`, `awaiting_customer_reply`, and `cancelled` action statuses; fixed cancel endpoint path
- **UI polish** — Agent controls wrap on small screens; collapsible actions panel with shared pill styles

## Test plan

- [ ] Open an escalated item — escalated step shows amber warning icon and **Escalated** label (not blue checkmark)
- [ ] Open an in-progress item with a rejected action — rejected step shows red X and **Rejected** label
- [ ] Cancel an in-progress workflow — confirm dialog, loading state, success toast, item moves to cancelled
- [ ] After cancel — cancelled action shows gray stop icon and **Cancelled** label (distinct from rejected)
- [ ] Verify agent enable/moderation controls still work and layout is OK on narrow viewports

### Commits

```
829a5cf feat(approval-queue): action status stepper visuals and cancel workflow API
```

## Notes

Cancel is only shown for workflow status `in_progress`. Reject (single action) and cancel (whole workflow) remain separate flows per backend docs.

## Rollback

Revert this PR; no migrations or env changes required.
