### PR TITLE
fix(ai-assistant): improve escalation queue mobile layout and navigation

### DIFF
--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-header/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-header/index.tsx
@@ -15,11 +15,11 @@ const AiAssistantHeader = () => {
   return (
     <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
       <div className="flex flex-col gap-1">
-        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight text-foreground">
-          <AI_ASSISTANT_ICON className="h-6 w-6 text-primary" />
+        <h1 className="flex items-center gap-2 text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+          <AI_ASSISTANT_ICON className="h-5 w-5 text-primary sm:h-6 sm:w-6" />
           AI Assistant
         </h1>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-xs text-muted-foreground sm:text-sm">
           Resolve complex cases with AI-powered assistance.
         </p>
       </div>
@@ -29,7 +29,7 @@ const AiAssistantHeader = () => {
           <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
           <span className="relative inline-flex h-2 w-2 rounded-full bg-emerald-500" />
         </span>
-        <Radio className="h-3 w-3" />
+        <Radio className="hidden h-3 w-3 sm:inline" />
         <span className="font-medium text-foreground/80">Live</span>
         <span aria-hidden>·</span>
         <span>{totalLabel}</span>

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/emails-list/components/email-card/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/emails-list/components/email-card/index.tsx
@@ -115,10 +115,14 @@ const EscalationEmailCard = (escalation: EscalationType) => {
 
       <div className="min-w-0 flex-1">
         <div className="flex items-start gap-2">
-          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground capitalize">
+          {/* Full subject is preserved across all widths — never truncated.
+              `break-words` handles long unbroken tokens, and the tight
+              `leading-snug` keeps multi-line subjects from inflating the
+              card height too aggressively. */}
+          <p className="min-w-0 flex-1 break-words text-sm font-medium leading-snug text-foreground capitalize">
             {email?.subject || "(No subject)"}
           </p>
-          <span className="shrink-0 text-[11px] text-muted-foreground tabular-nums">
+          <span className="shrink-0 pt-0.5 text-[11px] text-muted-foreground tabular-nums">
             {formatRelativeTime(createdAt)}
           </span>
         </div>
@@ -132,7 +136,7 @@ const EscalationEmailCard = (escalation: EscalationType) => {
           )}
         </p>
 
-        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        <div className="mt-2 flex flex-wrap items-center gap-x-1.5 gap-y-1">
           <Badge
             variant="outline"
             className={cn(
@@ -155,7 +159,7 @@ const EscalationEmailCard = (escalation: EscalationType) => {
           {hasConfidence && (
             <span
               className={cn(
-                "inline-flex items-center gap-1 text-[10px] font-medium tabular-nums",
+                "inline-flex shrink-0 items-center gap-1 text-[10px] font-medium tabular-nums",
                 getConfidenceTone(confidence),
               )}
               title={`AI confidence ${confidence}%`}

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/escalation-bulk-action-bar/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/escalation-bulk-action-bar/index.tsx
@@ -34,14 +34,28 @@ const EscalationBulkActionBar: FC = () => {
     updateEscalationStatus({ type: "bulk", escalationIds: ids, status });
 
   return (
-    <div className="flex flex-col gap-2 border-b border-primary/20 bg-primary/5 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex items-center gap-2 text-sm">
-        {isPending && (
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
-        )}
-        <span className="font-medium text-foreground">
-          {count} selected
-        </span>
+    <div className="flex flex-col gap-2 border-b border-primary/20 bg-primary/5 px-3 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-4">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <div className="flex items-center gap-2">
+          {isPending && (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+          )}
+          <span className="font-medium text-foreground">
+            {count} selected
+          </span>
+        </div>
+        {/* Clear button sits next to the count on small screens so the
+            primary status buttons get the full second row. */}
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={isPending}
+          onClick={() => setSelectedEmailsForBulkAction(new Set())}
+          className="h-7 px-2 text-xs sm:hidden"
+          aria-label="Clear selection"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
       </div>
       <div className="flex flex-wrap items-center gap-1.5">
         {escalationStatus !== EscalationStatus.PENDING && (
@@ -50,7 +64,7 @@ const EscalationBulkActionBar: FC = () => {
             variant="outline"
             disabled={isPending}
             onClick={() => apply(EscalationStatus.PENDING)}
-            className="h-7 gap-1 px-2 text-xs"
+            className="h-8 flex-1 gap-1 px-2 text-xs sm:h-7 sm:flex-none"
           >
             <RotateCcw className="h-3 w-3" />
             Pending
@@ -62,7 +76,7 @@ const EscalationBulkActionBar: FC = () => {
             variant="outline"
             disabled={isPending}
             onClick={() => apply(EscalationStatus.IN_PROGRESS)}
-            className="h-7 gap-1 px-2 text-xs"
+            className="h-8 flex-1 gap-1 px-2 text-xs sm:h-7 sm:flex-none"
           >
             <Clock className="h-3 w-3" />
             In Progress
@@ -73,7 +87,7 @@ const EscalationBulkActionBar: FC = () => {
             size="sm"
             disabled={isPending}
             onClick={() => apply(EscalationStatus.RESOLVED)}
-            className="h-7 gap-1 px-2 text-xs"
+            className="h-8 flex-1 gap-1 px-2 text-xs sm:h-7 sm:flex-none"
           >
             <CheckCircle2 className="h-3 w-3" />
             Resolve
@@ -84,7 +98,7 @@ const EscalationBulkActionBar: FC = () => {
           variant="ghost"
           disabled={isPending}
           onClick={() => setSelectedEmailsForBulkAction(new Set())}
-          className="h-7 gap-1 px-2 text-xs"
+          className="hidden h-7 gap-1 px-2 text-xs sm:inline-flex"
           aria-label="Clear selection"
         >
           <X className="h-3 w-3" />

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/escalation-pagination/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-emails-list/components/escalation-pagination/index.tsx
@@ -70,7 +70,9 @@ const EscalationPagination = () => {
 
   return (
     <div className="border-t bg-background px-3 py-2.5">
-      <div className="mb-2 flex items-center justify-between text-[11px] text-muted-foreground">
+      {/* Range/page summary — hidden on <sm to give the page navigator the
+          full width without crowding tap targets. */}
+      <div className="mb-2 hidden items-center justify-between text-[11px] text-muted-foreground sm:flex">
         <p>
           <span className="font-medium text-foreground tabular-nums">
             {rangeStart}

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-filters-bar/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation-filters-bar/index.tsx
@@ -1,6 +1,13 @@
 "use client";
 import { FC } from "react";
-import { Search, Calendar, X, ChevronDown } from "lucide-react";
+import {
+  Search,
+  Calendar,
+  X,
+  ChevronDown,
+  Check,
+  SlidersHorizontal,
+} from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import {
@@ -172,11 +179,24 @@ const EscalationFiltersBar: FC = () => {
     !!dateRange.from ||
     !!dateRange.to;
 
+  // Selected priority label for the compact dropdown trigger shown below xl.
+  // Falls back to a generic "Priority" so the trigger never collapses to a
+  // bare icon on tiny widths.
+  const activePriorityKey =
+    escalationPriority &&
+    (escalationPriority as keyof typeof ESCALATION_PRIORITY_LABEL);
+  const activePriorityLabel = activePriorityKey
+    ? ESCALATION_PRIORITY_LABEL[activePriorityKey]
+    : null;
+  const ActivePriorityIcon = activePriorityKey
+    ? ESCALATION_PRIORITY_ICON[activePriorityKey]
+    : SlidersHorizontal;
+
   return (
     <div className="flex flex-col gap-3">
       {/* Top row: search + priority chips + date range */}
-      <div className="flex flex-col gap-2 lg:flex-row lg:items-center">
-        <div className="relative lg:max-w-xs lg:flex-1">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:flex-wrap">
+        <div className="relative w-full sm:max-w-sm sm:flex-1 xl:max-w-xs">
           <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder="Search by subject, sender, or content..."
@@ -189,8 +209,74 @@ const EscalationFiltersBar: FC = () => {
           />
         </div>
 
-        <div className="flex flex-wrap items-center gap-1.5 lg:ml-auto">
-          {/* Priority chips. "All" reads as the implicit-off state. */}
+        {/* Compact priority dropdown — visible below xl where the chip strip
+            would otherwise crowd the search input. */}
+        <div className="flex items-center gap-1.5 sm:ml-auto xl:hidden">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className={cn(
+                  "h-8 gap-1.5",
+                  escalationPriority &&
+                    "border-primary/40 bg-primary/5 text-primary",
+                )}
+              >
+                <ActivePriorityIcon className="h-3.5 w-3.5" />
+                <span>{activePriorityLabel ?? "All priorities"}</span>
+                <ChevronDown className="h-3 w-3 opacity-60" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-44">
+              <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                Filter by priority
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => onChangePriority(null)}>
+                <span className="flex flex-1 items-center gap-2">
+                  <SlidersHorizontal className="h-3.5 w-3.5 text-muted-foreground" />
+                  <span>All priorities</span>
+                </span>
+                {escalationPriority === null && (
+                  <Check className="ml-2 h-3.5 w-3.5 text-primary" />
+                )}
+              </DropdownMenuItem>
+              {PRIORITY_ORDER.map((priority) => {
+                const key = priority as keyof typeof ESCALATION_PRIORITY_LABEL;
+                const Icon = ESCALATION_PRIORITY_ICON[key];
+                const isActive = escalationPriority === priority;
+                return (
+                  <DropdownMenuItem
+                    key={priority}
+                    onSelect={() =>
+                      onChangePriority(isActive ? null : priority)
+                    }
+                  >
+                    <span className="flex flex-1 items-center gap-2">
+                      <Icon className="h-3.5 w-3.5 text-muted-foreground" />
+                      <span>{ESCALATION_PRIORITY_LABEL[key]}</span>
+                    </span>
+                    {isActive && (
+                      <Check className="ml-2 h-3.5 w-3.5 text-primary" />
+                    )}
+                  </DropdownMenuItem>
+                );
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          <DateRangeDropdown
+            dateLabel={dateLabel}
+            onSelectDatePreset={onSelectDatePreset}
+            onClearDate={clearDate}
+          />
+        </div>
+
+        {/* Power-user priority chip strip — only at xl+ where the row has the
+            horizontal budget to render all 5 chips alongside the search input
+            and the date button without wrapping. */}
+        <div className="hidden xl:ml-auto xl:flex xl:flex-wrap xl:items-center xl:gap-1.5">
           <PriorityChip
             label="All priorities"
             isActive={escalationPriority === null}
@@ -198,10 +284,6 @@ const EscalationFiltersBar: FC = () => {
             family={null}
           />
           {PRIORITY_ORDER.map((priority) => {
-            // PRIORITY_ORDER is statically typed to the four real priorities,
-            // but TS widens the index expression to `EscalationPriority`
-            // (which includes ALL) when used to look up into our maps. Narrow
-            // explicitly via the local map key type.
             const key = priority as keyof typeof ESCALATION_PRIORITY_LABEL;
             const Icon = ESCALATION_PRIORITY_ICON[key];
             return (
@@ -220,44 +302,11 @@ const EscalationFiltersBar: FC = () => {
             );
           })}
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                className={cn(
-                  "ml-1 h-8 gap-1.5",
-                  dateLabel && "border-primary/40 bg-primary/5 text-primary",
-                )}
-              >
-                <Calendar className="h-3.5 w-3.5" />
-                <span>{dateLabel ?? "Any time"}</span>
-                <ChevronDown className="h-3 w-3 opacity-60" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
-                Filter by created date
-              </DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              {DATE_PRESETS.map((preset) => (
-                <DropdownMenuItem
-                  key={preset.id}
-                  onSelect={() => onSelectDatePreset(preset)}
-                >
-                  {preset.label}
-                </DropdownMenuItem>
-              ))}
-              {dateLabel && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={clearDate}>
-                    Clear date filter
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <DateRangeDropdown
+            dateLabel={dateLabel}
+            onSelectDatePreset={onSelectDatePreset}
+            onClearDate={clearDate}
+          />
         </div>
       </div>
 
@@ -343,6 +392,57 @@ const PriorityChip: FC<PriorityChipProps> = ({
     </button>
   );
 };
+
+type DateRangeDropdownProps = {
+  dateLabel: string | null;
+  onSelectDatePreset: (preset: DatePreset) => void;
+  onClearDate: () => void;
+};
+
+const DateRangeDropdown: FC<DateRangeDropdownProps> = ({
+  dateLabel,
+  onSelectDatePreset,
+  onClearDate,
+}) => (
+  <DropdownMenu>
+    <DropdownMenuTrigger asChild>
+      <Button
+        variant="outline"
+        size="sm"
+        className={cn(
+          "h-8 gap-1.5",
+          dateLabel && "border-primary/40 bg-primary/5 text-primary",
+        )}
+      >
+        <Calendar className="h-3.5 w-3.5" />
+        <span>{dateLabel ?? "Any time"}</span>
+        <ChevronDown className="h-3 w-3 opacity-60" />
+      </Button>
+    </DropdownMenuTrigger>
+    <DropdownMenuContent align="end" className="w-44">
+      <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+        Filter by created date
+      </DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      {DATE_PRESETS.map((preset) => (
+        <DropdownMenuItem
+          key={preset.id}
+          onSelect={() => onSelectDatePreset(preset)}
+        >
+          {preset.label}
+        </DropdownMenuItem>
+      ))}
+      {dateLabel && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={onClearDate}>
+            Clear date filter
+          </DropdownMenuItem>
+        </>
+      )}
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
 
 type ActiveFilterChipProps = {
   label: string;

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/ai-assistant-response/components/high-confidence-response/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/ai-assistant-response/components/high-confidence-response/index.tsx
@@ -51,8 +51,10 @@ const HighConfidenceResponse: FC<EscalationType> = ({
       </div>
 
       {/* Action bar — primary Send + signature toggle live together to
-          keep the "ready to send?" decisions close to each other. */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
+          keep the "ready to send?" decisions close to each other. On <sm
+          the bar stacks: secondary actions on top, then the signature
+          toggle and a full-width Send so it's reachable with one thumb. */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
         <div className="flex items-center gap-2">
           <Checkbox
             id={`signature-${id}`}
@@ -69,7 +71,7 @@ const HighConfidenceResponse: FC<EscalationType> = ({
           </label>
         </div>
 
-        <div className="flex items-center gap-1.5">
+        <div className="flex flex-wrap items-center gap-1.5">
           <Button
             type="button"
             variant="ghost"
@@ -112,7 +114,7 @@ const HighConfidenceResponse: FC<EscalationType> = ({
             size="sm"
             onClick={onSend}
             disabled={isPending || !draft.trim()}
-            className={cn("h-8 gap-1 px-3 text-xs")}
+            className={cn("ml-auto h-8 gap-1 px-3 text-xs sm:ml-0")}
           >
             {isPending ? (
               <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/ai-assistant-response/components/low-confidence-response/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/ai-assistant-response/components/low-confidence-response/index.tsx
@@ -122,7 +122,7 @@ const LowConfidenceResponse: FC<EscalationType> = ({ id }) => {
             placeholder="Write your response to the customer..."
           />
 
-          <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
             <SignatureToggle
               id={`signature-manual-${id}`}
               checked={manualSignature}
@@ -132,7 +132,7 @@ const LowConfidenceResponse: FC<EscalationType> = ({ id }) => {
               size="sm"
               onClick={handleSendManual}
               disabled={isSending || !manualText.trim()}
-              className="h-8 gap-1 px-3 text-xs"
+              className="h-8 w-full gap-1 px-3 text-xs sm:w-auto"
             >
               {isSending ? (
                 <Loader2 className="h-3 w-3 animate-spin" />
@@ -212,7 +212,7 @@ const LowConfidenceResponse: FC<EscalationType> = ({ id }) => {
                 className="min-h-[140px] resize-y border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
                 placeholder="AI response will appear here..."
               />
-              <div className="flex flex-wrap items-center justify-between gap-3 border-t pt-3">
+              <div className="flex flex-col gap-3 border-t pt-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
                 <SignatureToggle
                   id={`signature-ai-${id}`}
                   checked={aiSignature}
@@ -222,7 +222,7 @@ const LowConfidenceResponse: FC<EscalationType> = ({ id }) => {
                   size="sm"
                   onClick={handleSendAi}
                   disabled={isSending || !editableAiResponse.trim()}
-                  className="h-8 gap-1 px-3 text-xs"
+                  className="h-8 w-full gap-1 px-3 text-xs sm:w-auto"
                 >
                   {isSending ? (
                     <Loader2 className="h-3 w-3 animate-spin" />

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/email-preview-header/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/components/email-preview-header/index.tsx
@@ -17,12 +17,14 @@ import {
   formatRelativeTime,
 } from "@/modules/protected-routes/ai-assistant/utils/format-escalation-date";
 import {
+  ArrowLeft,
   CheckCircle2,
   Clock,
   Loader2,
   RotateCcw,
   User,
 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const normalizeStatus = (status: string) =>
   status === "in_progress" ? "progress" : status;
@@ -35,8 +37,11 @@ const parseFromAddress = (raw: string | null | undefined) => {
 };
 
 const EmailPreviewHeader = () => {
-  const { selectedEscalationDetails } = useAiAssistant();
+  const { selectedEscalationDetails, setSelectedEscalationForPreview } =
+    useAiAssistant();
   const { isPending, updateEscalationStatus } = useUpdateEscalationStatus();
+  const router = useRouter();
+  const searchParams = useSearchParams();
 
   if (!selectedEscalationDetails) return null;
 
@@ -61,11 +66,44 @@ const EmailPreviewHeader = () => {
       status: next,
     });
 
+  // Mobile-only back affordance. We clear both the local selection AND the
+  // deep-link query param so the user can't bounce right back to the same
+  // detail on the next render (the provider re-syncs from the URL).
+  const onBackToInbox = () => {
+    setSelectedEscalationForPreview(null);
+    if (searchParams.has("escalationId") || searchParams.has("email")) {
+      router.replace("/ai-assistant", { scroll: false });
+    }
+  };
+
   return (
     <div className="sticky top-0 z-10 border-b bg-background/95 px-5 py-4 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      {/* Back-to-inbox is the user's primary navigation handle on small
+          screens. We use a solid charcoal fill (bg-foreground / text-
+          background via design tokens) because:
+            • the inverse contrast pops on the white card without competing
+              with brand-blue primary CTAs like "Send response",
+            • the rectangular shape + drop shadow reads as a structural
+              button rather than a tag/chip,
+            • the arrow slides left on hover for a "swipe-back" affordance. */}
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onBackToInbox}
+        aria-label="Back to inbox"
+        className="group mb-3 h-9 gap-2 rounded-md bg-foreground px-3.5 text-sm font-semibold text-background shadow-sm transition-all hover:bg-foreground/90 hover:text-background hover:shadow active:bg-foreground/85 lg:hidden"
+      >
+        <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
+        Back to inbox
+      </Button>
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0 flex-1">
-          <h2 className="truncate text-lg font-semibold capitalize text-foreground">
+          {/* Subject is the single highest-context line in the entire panel,
+              so it never truncates. `break-words` keeps URL-like tokens from
+              overflowing the panel; the action buttons sit at `lg:items-start`
+              so they keep their top-right anchor as the subject grows. */}
+          <h2 className="text-lg font-semibold capitalize text-foreground break-words">
             {email?.subject || "(No subject)"}
           </h2>
           <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/components/escalation_email_preview/index.tsx
@@ -2,22 +2,37 @@
 import { cn } from "@/lib/utils";
 import { ESCALATION_EMAIL_PREVIEW_PROPS } from "../../types/escalation-email-preview";
 import { Card } from "@/components/ui/card";
-import { Loader2, MailOpen, SearchX } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Loader2, MailOpen, SearchX } from "lucide-react";
 import EmailPreviewHeader from "./components/email-preview-header";
 import EmailPreviewContent from "./components/email-preview-content";
 import AiAssistantResponse from "./components/ai-assistant-response";
 import EscalationContextCallout from "./components/escalation-context-callout";
 import { useAiAssistant } from "@/providers/ai-assistant";
+import { useRouter, useSearchParams } from "next/navigation";
 
 const EscalationEmailPreview = ({
   className,
 }: ESCALATION_EMAIL_PREVIEW_PROPS) => {
   const {
     selectedEscalationDetails,
+    setSelectedEscalationForPreview,
     deepLinkedEscalationId,
     isResolvingDeepLinkedEscalation,
     isDeepLinkedEscalationNotFound,
   } = useAiAssistant();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  // Same back affordance as the populated preview header — needed for the
+  // loading / not-found states so a user who arrived via a stale deep link
+  // can still get back to the inbox on small screens.
+  const onBackToInbox = () => {
+    setSelectedEscalationForPreview(null);
+    if (searchParams.has("escalationId") || searchParams.has("email")) {
+      router.replace("/ai-assistant", { scroll: false });
+    }
+  };
 
   if (selectedEscalationDetails) {
     return (
@@ -28,7 +43,7 @@ const EscalationEmailPreview = ({
         )}
       >
         <EmailPreviewHeader />
-        <div className="flex flex-col gap-5 px-5 py-5">
+        <div className="flex flex-col gap-5 px-4 py-5 sm:px-5">
           <EscalationContextCallout />
           <EmailPreviewContent />
           <AiAssistantResponse />
@@ -37,57 +52,81 @@ const EscalationEmailPreview = ({
     );
   }
 
+  const isAwaitingDeepLink =
+    isResolvingDeepLinkedEscalation || isDeepLinkedEscalationNotFound;
+
   return (
     <Card
       className={cn(
-        "flex min-h-[420px] items-center justify-center border-dashed",
+        "flex min-h-[420px] flex-col border-dashed",
         className,
       )}
     >
-      <div className="max-w-xs text-center">
-        {isResolvingDeepLinkedEscalation ? (
-          <>
-            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
-            </div>
-            <p className="text-sm font-medium text-foreground">
-              Opening escalation...
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Loading details for ticket{" "}
-              <span className="font-mono">{deepLinkedEscalationId}</span>
-            </p>
-          </>
-        ) : isDeepLinkedEscalationNotFound ? (
-          <>
-            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-rose-50 text-rose-600">
-              <SearchX className="h-5 w-5" />
-            </div>
-            <p className="text-sm font-medium text-foreground">
-              Escalation not found
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Ticket{" "}
-              <span className="font-mono">
-                {deepLinkedEscalationId || "unknown"}
-              </span>{" "}
-              is unavailable or no longer accessible.
-            </p>
-          </>
-        ) : (
-          <>
-            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-              <MailOpen className="h-5 w-5 text-muted-foreground" />
-            </div>
-            <p className="text-sm font-medium text-foreground">
-              Select an escalation
-            </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Choose a ticket from the list to view the customer email,
-              escalation context, and AI suggested response.
-            </p>
-          </>
-        )}
+      {/* The empty-no-selection state only ever renders on lg+ (the small-
+          screen layout hides the preview when there's no selection). The
+          loading / not-found states CAN render on small screens via deep
+          links, so we expose a back button on those. */}
+      {isAwaitingDeepLink && (
+        <div className="border-b border-dashed px-4 py-3 lg:hidden">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onBackToInbox}
+            aria-label="Back to inbox"
+            className="group h-9 gap-2 rounded-md bg-foreground px-3.5 text-sm font-semibold text-background shadow-sm transition-all hover:bg-foreground/90 hover:text-background hover:shadow active:bg-foreground/85"
+          >
+            <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />
+            Back to inbox
+          </Button>
+        </div>
+      )}
+      <div className="flex flex-1 items-center justify-center px-4 py-8">
+        <div className="max-w-xs text-center">
+          {isResolvingDeepLinkedEscalation ? (
+            <>
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+              <p className="text-sm font-medium text-foreground">
+                Opening escalation...
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Loading details for ticket{" "}
+                <span className="font-mono">{deepLinkedEscalationId}</span>
+              </p>
+            </>
+          ) : isDeepLinkedEscalationNotFound ? (
+            <>
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-rose-50 text-rose-600">
+                <SearchX className="h-5 w-5" />
+              </div>
+              <p className="text-sm font-medium text-foreground">
+                Escalation not found
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Ticket{" "}
+                <span className="font-mono">
+                  {deepLinkedEscalationId || "unknown"}
+                </span>{" "}
+                is unavailable or no longer accessible.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
+                <MailOpen className="h-5 w-5 text-muted-foreground" />
+              </div>
+              <p className="text-sm font-medium text-foreground">
+                Select an escalation
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Choose a ticket from the list to view the customer email,
+                escalation context, and AI suggested response.
+              </p>
+            </>
+          )}
+        </div>
       </div>
     </Card>
   );

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/components/escalation-queue-tab/index.tsx
@@ -1,16 +1,75 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useAiAssistant } from "@/providers/ai-assistant";
 import EscalationQueueEmailsList from "./components/escalation-emails-list";
 import EscalationEmailPreview from "./components/escalation_email_preview";
 import EscalationEmailResponseFeedbackDialog from "./components/escalation_email_preview/components/feedback-dialog";
 import EscalationFiltersBar from "./components/escalation-filters-bar";
 
+/**
+ * Master-detail layout.
+ *
+ *  - lg+ : list + preview always side-by-side (40% / 60%).
+ *  - <lg : panels are mutually exclusive. The list is the default surface;
+ *          tapping a card swaps it for the preview, which carries its own
+ *          "Back to inbox" affordance in the sticky header. This keeps the
+ *          mobile experience consistent with Gmail / Outlook / Linear and
+ *          avoids the "scroll-past-the-list-to-see-the-preview" trap of a
+ *          plain stacked layout.
+ */
 const EscalationQueueTab = () => {
+  const { selectedEscalationForPreview, deepLinkedEscalationId } =
+    useAiAssistant();
+  const hasActivePreview =
+    !!selectedEscalationForPreview || !!deepLinkedEscalationId;
+
+  // The master-detail panel needs a scroll anchor so we can land the
+  // viewport precisely at the top of the preview (where "Back to inbox"
+  // lives) instead of slamming back to the page header. The DashboardNavbar
+  // is `sticky top-0` with `h-16` (64px), so the scroll-margin has to be
+  // at least that tall — otherwise the preview's top hides BEHIND the
+  // navbar. `scroll-mt-20` = 80px = 64px navbar + 16px breathing room so
+  // the back button is the first thing visible below the chrome.
+  const previewSectionRef = useRef<HTMLDivElement>(null);
+
+  // When the user taps into a preview on small screens, the preview replaces
+  // the list at the same DOM position — but the user may have been scrolled
+  // deep into the list. We want the Back-to-inbox button to be the first
+  // thing they see, NOT the page header / stats strip / filters bar above
+  // it. So we anchor the scroll to the preview section instead of the page
+  // top. On lg+ we keep the user where they were because both panels stay
+  // mounted side-by-side.
+  useEffect(() => {
+    if (!selectedEscalationForPreview) return;
+    if (typeof window === "undefined") return;
+    if (window.matchMedia("(min-width: 1024px)").matches) return;
+    previewSectionRef.current?.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+    });
+  }, [selectedEscalationForPreview]);
+
   return (
     <div className="flex flex-col gap-4">
       <EscalationFiltersBar />
 
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-5">
-        <EscalationQueueEmailsList className="lg:col-span-2" />
-        <EscalationEmailPreview className="lg:col-span-3" />
+      <div
+        ref={previewSectionRef}
+        className="grid grid-cols-1 gap-4 scroll-mt-20 lg:grid-cols-5"
+      >
+        <EscalationQueueEmailsList
+          className={cn(
+            "lg:col-span-2 lg:block",
+            hasActivePreview && "hidden",
+          )}
+        />
+        <EscalationEmailPreview
+          className={cn(
+            "lg:col-span-3 lg:block",
+            !hasActivePreview && "hidden",
+          )}
+        />
       </div>
 
       <EscalationEmailResponseFeedbackDialog />

--- a/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/ai-assistant-tabs/index.tsx
@@ -21,14 +21,16 @@ const AiAssistantTabs = () => {
           className="inline-flex h-7 items-center gap-1.5 rounded-sm px-3 text-xs font-medium cursor-pointer data-[state=active]:bg-background data-[state=active]:shadow-sm"
         >
           <LayoutList className="h-3.5 w-3.5" />
-          Escalation Queue
+          <span className="sm:hidden">Queue</span>
+          <span className="hidden sm:inline">Escalation Queue</span>
         </TabsTrigger>
         <TabsTrigger
           value="email-signature"
           className="inline-flex h-7 items-center gap-1.5 rounded-sm px-3 text-xs font-medium cursor-pointer data-[state=active]:bg-background data-[state=active]:shadow-sm"
         >
           <Signature className="h-3.5 w-3.5" />
-          Email Signature
+          <span className="sm:hidden">Signature</span>
+          <span className="hidden sm:inline">Email Signature</span>
         </TabsTrigger>
       </TabsList>
       <TabsContent value="escalation-queue">

--- a/src/modules/protected-routes/ai-assistant/components/escalation-stats-strip/index.tsx
+++ b/src/modules/protected-routes/ai-assistant/components/escalation-stats-strip/index.tsx
@@ -129,7 +129,7 @@ const StatTile: FC<StatTileProps> = ({
         "group relative flex h-full flex-col gap-2 overflow-hidden rounded-lg border bg-card p-3 text-left shadow-sm transition-colors",
         "hover:border-primary/40 hover:bg-muted/40",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-        "last:col-span-2 sm:last:col-span-1",
+        "last:col-span-2 sm:last:col-span-1 lg:last:col-span-1",
         isActive && "border-primary/40 bg-primary/5",
         heroEngaged && "border-orange-200/80 bg-orange-50/40",
         heroEngaged && isActive && "border-orange-300 bg-orange-50",
@@ -200,11 +200,11 @@ const EscalationStatsStrip: FC = () => {
 
   if (isStatsPending || !counts) {
     return (
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5">
         {TILES.map((tile) => (
           <Skeleton
             key={tile.key}
-            className="h-[88px] last:col-span-2 sm:last:col-span-1"
+            className="h-[88px] last:col-span-2 sm:last:col-span-1 lg:last:col-span-1"
           />
         ))}
       </div>
@@ -248,7 +248,7 @@ const EscalationStatsStrip: FC = () => {
 
   return (
     <div
-      className="grid grid-cols-2 gap-2 sm:grid-cols-3 xl:grid-cols-5"
+      className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-5"
       role="group"
       aria-label="Escalation queue summary"
     >


### PR DESCRIPTION
## Summary

Improves the AI Assistant escalation queue for mobile and small viewports. The list and preview now use a master-detail pattern on screens below `lg`, with a prominent "Back to inbox" control, scroll anchoring, and responsive filter/action layouts so agents can triage escalations on phones and tablets without horizontal crowding or truncated subjects.

## Changes

### Mobile master-detail layout
- **Escalation queue tab**: List and preview are mutually exclusive below `lg`; selecting a card swaps to the preview panel with smooth scroll-to-preview anchored below the sticky navbar.
- **Email preview header & empty states**: Added mobile-only "Back to inbox" button that clears selection and deep-link query params (`escalationId`, `email`).

### Responsive UI polish
- **Header & tabs**: Smaller typography on mobile; shortened tab labels ("Queue", "Signature").
- **Stats strip**: 5-column grid at `lg+` instead of `xl+`.
- **Filters bar**: Compact priority dropdown below `xl`; extracted reusable `DateRangeDropdown`; chip strip reserved for `xl+`.
- **Email cards**: Full subject with `break-words` instead of truncation.
- **Bulk action bar**: Full-width status buttons on mobile; clear button repositioned for thumb reach.
- **Pagination**: Range summary hidden on small screens.
- **AI response actions**: Stacked layout with full-width Send buttons on mobile.

## Testing checklist

- [ ] On mobile (<1024px), escalation list shows by default; tapping a card opens preview and scrolls to "Back to inbox"
- [ ] "Back to inbox" returns to list and clears `escalationId`/`email` URL params
- [ ] Deep-link to missing escalation shows back button on mobile
- [ ] Priority filter dropdown works below `xl`; chip strip visible at `xl+`
- [ ] Bulk select bar: status buttons span full width on mobile; clear button accessible
- [ ] Email subjects wrap instead of truncating in list and preview header
- [ ] Send / signature controls stack correctly in high- and low-confidence response panels
- [ ] Desktop (`lg+`) layout unchanged: side-by-side list + preview

### Commits

```
f115e34 fix(ai-assistant): improve escalation queue mobile layout and navigation
```

## Notes

- Vercel preview deploy should attach to this PR after merge review.
- Rollback: revert commit `f115e34` if mobile layout regressions appear on desktop.
