### PR TITLE
fix(dashboard): dedupe activity logs and refine awaiting-approval styling

### DIFF
--- a/src/hooks/services/activity-log/use-activity-log/index.ts
+++ b/src/hooks/services/activity-log/use-activity-log/index.ts
@@ -7,6 +7,17 @@ type UseActivityLogOptions = {
   enabled?: boolean;
 };
 
+const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
+  const seen = new Set<string>();
+  const output: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.id)) continue;
+    seen.add(item.id);
+    output.push(item);
+  }
+  return output;
+};
+
 export const useActivityLog = ({
   limit = 10,
   enabled = true,
@@ -33,10 +44,10 @@ export const useActivityLog = ({
     enabled,
   });
 
-  const activityLogs = useMemo(
-    () => data?.pages.flatMap((p) => p.data) ?? [],
-    [data?.pages],
-  );
+  const activityLogs = useMemo(() => {
+    const flat = data?.pages.flatMap((p) => p.data) ?? [];
+    return dedupeById(flat);
+  }, [data?.pages]);
 
   return {
     activityLogs,

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx
@@ -163,13 +163,6 @@ export const ApprovalQueueItem: FC<ApprovalQueueItemData> = ({
         isAwaitingApproval && "ring-1 ring-orange-200/70",
       )}
     >
-      {isAwaitingApproval && (
-        <div
-          className={cn("h-1 w-full", pendingApprovalStyles.accentBar)}
-          aria-hidden
-        />
-      )}
-
       <Collapsible
         open={isActionsOpen}
         onOpenChange={handleActionsOpenChange}

--- a/src/modules/protected-routes/approval-queue/components/approval-queue-stats/index.tsx
+++ b/src/modules/protected-routes/approval-queue/components/approval-queue-stats/index.tsx
@@ -140,21 +140,13 @@ const StatTile: FC<StatTileProps> = ({
         // column from sm upwards.
         "last:col-span-2 sm:last:col-span-1",
         isActive && "border-primary/40 bg-primary/5",
-        // Hero-only structural treatment: top accent strip + tinted card
-        // background + border tint. These are the three signals that keep
-        // the Awaiting tile dominant now that every tile has a color
-        // identity of its own.
+        // Hero-only structural treatment: tinted card background + border
+        // tint. This keeps the Awaiting tile dominant now that every tile
+        // has a color identity of its own.
         heroEngaged && "border-orange-200/80 bg-orange-50/40",
         heroEngaged && isActive && "border-orange-300 bg-orange-50",
       )}
     >
-      {heroEngaged && (
-        <span
-          className="absolute inset-x-0 top-0 h-0.5 bg-orange-500"
-          aria-hidden
-        />
-      )}
-
       {/* Top row: label leads, icon trails. The label is the small
           contextual title ("what am I looking at?") and the icon is a
           quiet accent — together they form one semantic unit (Gestalt

--- a/src/modules/protected-routes/dashboard/components/ActivityLog.tsx
+++ b/src/modules/protected-routes/dashboard/components/ActivityLog.tsx
@@ -125,6 +125,10 @@ const ItemCard: FC<ActivityLogItem> = ({
     : null;
 
   const occurredAt = useMemo(() => new Date(timestamp), [timestamp]);
+  const normalizedMessage = message.trim().toLowerCase();
+  const normalizedActionName = actionName.trim().toLowerCase();
+  const shouldShowMessage =
+    normalizedMessage.length > 0 && normalizedMessage !== normalizedActionName;
 
   return (
     <div
@@ -188,7 +192,9 @@ const ItemCard: FC<ActivityLogItem> = ({
         {actionName ? (
           <p className="text-sm font-medium text-gray-800">{actionName}</p>
         ) : null}
-        <p className="break-words text-sm text-gray-900">{message}</p>
+        {shouldShowMessage ? (
+          <p className="break-words text-sm text-gray-900">{message}</p>
+        ) : null}
         <p className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500">
           <Mail className="h-3 w-3" aria-hidden />
           <span className="break-all">{customerEmail}</span>


### PR DESCRIPTION
## Summary
- Deduplicate activity-log entries by `id` when paginating the dashboard feed to prevent repeated rows across pages.
- Improve activity-log readability by suppressing duplicate body text when `message` and `actionName` are the same semantic content.
- Simplify approval-queue awaiting-approval visuals by removing the orange top accent line from both the top stats tile and awaiting-approval list cards while preserving existing status colors and badges.

## Changes
- `src/hooks/services/activity-log/use-activity-log/index.ts`
  - Added ID-based de-duplication for flattened infinite-query pages before exposing `activityLogs`.
- `src/modules/protected-routes/dashboard/components/ActivityLog.tsx`
  - Added normalized message/action comparison and render guard to avoid repeated text blocks.
- `src/modules/protected-routes/approval-queue/components/approval-queue-stats/index.tsx`
  - Removed hero tile top accent strip for `Awaiting Approval` while keeping tint and border emphasis.
- `src/modules/protected-routes/approval-queue/components/approval-queue-items-list/components/approval-queue-item/index.tsx`
  - Removed awaiting-approval card top accent bar while preserving ring and action panel styling.

## Testing Checklist
- [ ] Verify dashboard activity log no longer shows duplicate rows when loading additional pages.
- [ ] Verify dashboard activity log does not repeat action text when message/action are equivalent.
- [ ] Verify approval queue `Awaiting Approval` top summary tile no longer shows the orange top line.
- [ ] Verify awaiting-approval queue cards no longer show the orange top bar.
- [ ] Verify other status colors, pills, and workflow indicators are unchanged.

### Commits
2287285 fix(approval-queue): remove awaiting-approval top accent bars
bf241f6 fix(dashboard): dedupe activity logs and hide redundant messages

## Notes / Rollback
- Rollback by reverting commits `2287285` and `bf241f6` if visual/status or activity-log behavior needs to be restored.
